### PR TITLE
Add 'codeType' to requestToken for non-standard providers

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -182,6 +182,8 @@ Optional Parameters
 
 * ``grantType``: Defaults to "authorization_code". Should only be changed if
   you're dealing with an OAuth 2.0 extension and you know what you're doing.
+  
+* ``codeType``: Defaults to "code". This is the request key where the OAuth2 provider expects the auth code, if non-standard. Should only be changed if you're dealing with an OAuth 2.0 extension and you know what you're doing.
 
 Resource Request
 ----------------

--- a/lib/sanction.js
+++ b/lib/sanction.js
@@ -66,7 +66,11 @@ Client.prototype = {
         // (which .hasOwnProperty expects)
         if(opts.code != undefined) {
             o.data.redirect_uri = this.redirectUri;
-            o.data.code = opts.code;
+            if(opts.codeType != undefined) {
+                o.data[opts.codeType] = opts.code;
+            } else {
+                o.data.code = opts.code;
+            }
         }
         else if(opts.refreshToken != undefined) {
             o.data.refresh_token = opts.refreshToken;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "sanction",
-    "version": "0.1.1",
+    "version": "0.1.2",
     "author": "Demian Brecht <demianbrecht@gmail.com>",
     "contributors": [{ 
         "name": "Demian Brecht",


### PR DESCRIPTION
Hey there,

Thanks for writing sanction! It's made my job easier for a provider integration, but this particular provider has a lot of non-standard parts (including a weird `grantType` - thanks for making that an option!).

I just added an optional `codeType` since my provider requires this key to be named `auth_key` rather than the standard `code`.

Let me know if there's anything else I can do to clean up this PR, if needed.

Cheers!
